### PR TITLE
added error-handling for call_sync

### DIFF
--- a/src/dbus_proxy/_proxy.lua
+++ b/src/dbus_proxy/_proxy.lua
@@ -265,13 +265,13 @@ end
 --
 -- @param[type=Proxy] proxy a proxy object
 local function generate_fields(proxy)
-  local xml_data_str = introspect(proxy)
+  local xml_data_str, err = introspect(proxy)
 
   if not xml_data_str then
     error(
       string.format(
-        "Failed to introspect object '%s', XML data was %s",
-        proxy.name, xml_data_str
+        "Failed to introspect object '%s'\nerror: %s\ncode: %s",
+        proxy.name, err or "<unknown>", err.code or "<unknown>"
       )
     )
   end

--- a/src/dbus_proxy/_proxy.lua
+++ b/src/dbus_proxy/_proxy.lua
@@ -105,6 +105,11 @@ proxy = p.Proxy:new(
 proxy:SomeMethod()
 proxy:SomeMethodWithArguments("hello", 123)
 proxy.SomeProperty
+
+local res, err =  proxy:SomeMethodWithError()
+if not res and err then
+    print("Error:", err)
+end
 ]]
 local Proxy = {}
 

--- a/src/dbus_proxy/_proxy.lua
+++ b/src/dbus_proxy/_proxy.lua
@@ -147,11 +147,14 @@ end
 --
 local function call(proxy, interface, method, args)
   local params = build_params(args)
-  local out = proxy._proxy:call_sync(
+  local out,err = proxy._proxy:call_sync(
     interface .. "." .. method,
     params,
     DBusCallFlags.NONE,
     _DEFAULT_TIMEOUT)
+  if not out and err then
+    return out, err
+  end
   local result = variant.strip(out)
   if type(result) == "table" and #result == 1 then
     result = result[1]

--- a/tests/proxy_spec.lua
+++ b/tests/proxy_spec.lua
@@ -224,6 +224,25 @@ describe("DBus Proxy objects", function ()
                 )
            end)
 
+           it("reports an error if a call fails", function ()
+                local errfn = function()
+                    Proxy:new(
+                    {
+                      bus = Bus.SESSION,
+                      name = "org.freedesktop.some.name",
+                      path= "/org/freedesktop/Some/Path",
+                      interface = "org.freedesktop.some.interface"
+                    }
+                  )
+                end
+
+                assert.has_error(errfn,
+                  "Failed to introspect object 'org.freedesktop.some.name'\n" ..
+                  "error: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: " ..
+                  "The name org.freedesktop.some.name was not provided by any .service files\n" ..
+                  "code: SERVICE_UNKNOWN")
+           end)
+
            it("can access properties", function ()
                 -- This is a bit hacky, but I don't
                 -- know how to make it better.
@@ -321,6 +340,7 @@ describe("DBus Proxy objects", function ()
                   "Invalid signal: NotValid")
 
            end)
+
 end)
 
 describe("Monitored proxy objects", function ()


### PR DESCRIPTION
As mentioned at https://github.com/pavouk/lgi/blob/master/docs/guide.md#21-calling-functions-and-methods:
Functions reporting errors through GError ** as last argument use Lua standard error reporting - they
typically return boolean value indicating either success or failure, and if failure occurs,
following return values represent error message and error code.