### PR TITLE
fix unpack for luajit

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,4 +2,7 @@ std = "min"
 files["tests"] = {
 	std = "+busted";
 }
+read_globals = {
+    "table.unpack",
+}
 max_line_length = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - DISPLAY=fake
   matrix:
+    - LUA="luajit latest"
     - LUA="lua 5.2"
     - LUA="lua 5.3"
 

--- a/src/dbus_proxy/_proxy.lua
+++ b/src/dbus_proxy/_proxy.lua
@@ -18,6 +18,7 @@
 ---  @submodule dbus_proxy
 local string = string
 local table = table
+local unpack = unpack or table.unpack -- luacheck: globals unpack
 
 local lgi = require("lgi")
 
@@ -379,7 +380,7 @@ function Proxy:connect_signal(callback, signal_name, sender_name)
 
     if signal == signal_name then
       params = variant.strip(params)
-      return callback(self, table.unpack(params))
+      return callback(self, unpack(params))
     end
   end
 

--- a/tests/proxy_spec.lua
+++ b/tests/proxy_spec.lua
@@ -1,6 +1,7 @@
 -- Works with the 'busted' framework.
 -- http://olivinelabs.com/busted/
 local table = table
+local unpack = unpack or table.unpack -- luacheck: globals unpack
 require("busted")
 
 local GLib = require("lgi").GLib
@@ -316,7 +317,7 @@ describe("DBus Proxy objects", function ()
                 assert.is_true(called)
                 assert.equals(proxy, received_proxy)
                 assert.equals(3, #received_params)
-                local owned_name, old_owner, new_owner = table.unpack(received_params)
+                local owned_name, old_owner, new_owner = unpack(received_params)
                 assert.equals(bus_name, owned_name)
                 assert.equals('', old_owner)
                 assert.is_string(new_owner)


### PR DESCRIPTION
`table.unpack` is only available on `lua >= 5.2`.

This makes `dbus_proxy` also work with ~`lua 5.1`~ `luajit`, some tests will still fail with `lua 5.1`.