### PR TITLE
Use ibus's Gio.DBusConnectionFlags as default Gio.DBusConnectionFlags

### DIFF
--- a/src/dbus_proxy/_bus.lua
+++ b/src/dbus_proxy/_bus.lua
@@ -31,7 +31,7 @@ setmetatable(_Bus,
                    -- key = "unix:path=/run/user/1000/pulse/dbus-socket"
                    v = Gio.DBusConnection.new_for_address_sync(
                      key,
-                     Gio.DBusConnectionFlags.NONE)
+                     Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT + Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION)
                  end
                  rawset(tbl, key, v)
                  return v


### PR DESCRIPTION
https://github.com/ibus/ibus/blob/42be272730ca8efc0ca0a1dc1c79cd48f839da34/src/ibusbus.c#L546-L547

it will not affect normal dbus and will fix ibus.

Maybe fix #14
